### PR TITLE
Added CA and Proxy support

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -6,6 +6,13 @@ config:
   cluster_name: ocp4
   installer_ssh_key: "{{ lookup('file', '~/.ssh/ocp4.pub') }}"
   pull_secret: {"auths": ...}
+proxy:
+  enabled: False
+  http_proxy_url: http://user:passwd@proxy.example.com:3128
+  https_proxy_url: http://user:passwd@proxy.example.com:3128
+ca:
+  enabled: False
+  additionalTrustBundle: /root/ca.pem
 vcenter:
   ip: 192.168.86.100
   datastore: datastore1

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -10,6 +10,7 @@ proxy:
   enabled: False
   http_proxy_url: http://user:passwd@proxy.example.com:3128
   https_proxy_url: http://user:passwd@proxy.example.com:3128
+  noProxy: .example.com, git.example.com, vcenter-ip, control-planes-ip, machines-ip
 ca:
   enabled: False
   additionalTrustBundle: /root/ca.pem

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -82,6 +82,10 @@
     file:
       path: "{{ playbook_dir }}/bin/govc"
       mode: '775'
+      
+  - name: CA
+    shell: awk '{ print "   " $0 }' {{ ca.additionalTrustBundle }} > /tmp/ca.pem
+    when: "{{ ca.enabled }} == True"
 
   - name: Copy install-config.yaml file into install-dir
     template:

--- a/roles/common/templates/install-config.yaml.j2
+++ b/roles/common/templates/install-config.yaml.j2
@@ -4,7 +4,7 @@ baseDomain: {{ config.base_domain }}
 proxy:
   httpProxy: {{ proxy.http_proxy_url }}
   httpsProxy: {{ proxy.https_proxy_url }}
-  noProxy: {{ config.base_domain }}
+  noProxy: {{ proxy.noProxy }}
 {% endif %}
 {% if ca.enabled == True %}
 additionalTrustBundle: |

--- a/roles/common/templates/install-config.yaml.j2
+++ b/roles/common/templates/install-config.yaml.j2
@@ -1,5 +1,15 @@
 apiVersion: v1
 baseDomain: {{ config.base_domain }}
+{% if proxy.enabled == True %}
+proxy:
+  httpProxy: {{ proxy.http_proxy_url }}
+  httpsProxy: {{ proxy.https_proxy_url }}
+  noProxy: {{ config.base_domain }}
+{% endif %}
+{% if ca.enabled == True %}
+additionalTrustBundle: |
+{{ lookup('file','/tmp/ca.pem') }}
+{% endif %}
 compute:
 - hyperthreading: Enabled   
   name: worker


### PR DESCRIPTION
Sample template output

```
[root@vegeta ~]# cat install-config.yaml 
apiVersion: v1
baseDomain: example.com
proxy:
  httpProxy: http://user:passwd@proxy.example.com:3128
  httpsProxy: http://user:passwd@proxy.example.com:3128
  noProxy: example.com
additionalTrustBundle: |
   -----BEGIN CERTIFICATE-----
   <MY_TRUSTED_CA_CERT>
   -----END CERTIFICATE-----
compute:
- hyperthreading: Enabled   
  name: worker
  replicas: 0 
controlPlane:
  hyperthreading: Enabled   
  name: master
  replicas: 3 
metadata:
  name: ocp4
platform:
  vsphere:
    vcenter: 192.168.86.100
    username: administrator@vsphere.local
    password: something
    datacenter: dc
    defaultDatastore: datastore1
pullSecret: '{"auths": "..."}'
sshKey: 'ssh-rsa '
```