### PR TITLE
Modification to enable installations without a cloud-provider.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ As it stands right now, the repo works for several installation usecases:
 * Static IPs for nodes (lack of isolated network to let helper run DHCP server)
 * w/o Cluster-wide Proxy (HTTP and SSL/TLS with certs supported)
 * Restricted network 
+* No Cloud Provider (Useful for mixed clusters with both virtual and physical Nodes)
 
 > This repo is most ideal for Home Lab and Proof-of-Concept scenarios. Having said that, if prerequistes (below) can be met and if the vCenter service account can be locked down to access only certain resources and perform only certain actions, the same repo can then be used for DEV or higher environments. Refer to this [link](https://vmware.github.io/vsphere-storage-for-kubernetes/documentation/vcp-roles.html) for more details on required permissions for a vCenter service account.
 
@@ -68,6 +69,14 @@ As it stands right now, the repo works for several installation usecases:
       host: helper.ocp4.example.com
       port: 5000
       repo: ocp4/openshift4
+   ```
+9. If you wish to install without enabling the Kubernetes vSphere Cloud Provider (Useful for mixed installs with both Virtual Nodes and Bare Metal Nodes), change the `provider: ` to `none` in all.yaml.
+   Note: If `provider: none` then the vsphere attributes do not need to be provided.
+   ```
+   config:
+     provider: none
+     base_domain: example.com
+     ...
    ```
 
 > The step **#5** needn't exist at the time of running the setup/installation step, so provide an accurate guess of where and at what context path **bootstrap.ign** will eventually be served 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ As it stands right now, the repo works for several installation usecases:
 * Static IPs for nodes (lack of isolated network to let helper run DHCP server)
 * w/o Cluster-wide Proxy (HTTP and SSL/TLS with certs supported)
 * Restricted network 
+* No Cloud Provider 
 
 > This repo is most ideal for Home Lab and Proof-of-Concept scenarios. Having said that, if prerequistes (below) can be met and if the vCenter service account can be locked down to access only certain resources and perform only certain actions, the same repo can then be used for DEV or higher environments. Refer to this [link](https://vmware.github.io/vsphere-storage-for-kubernetes/documentation/vcp-roles.html) for more details on required permissions for a vCenter service account.
 
@@ -68,6 +69,13 @@ As it stands right now, the repo works for several installation usecases:
       host: helper.ocp4.example.com
       port: 5000
       repo: ocp4/openshift4
+   ```
+9. If you wish to install without enabling the Kubernetes vSphere Cloud Provider (Useful for mixed installs with both Virtual Nodes and Bare Metal Nodes), change the `provider: ` to `none` in all.yaml.
+   ```
+   config:
+     provider: none
+     base_domain: example.com
+     ...
    ```
 
 > The step **#5** needn't exist at the time of running the setup/installation step, so provide an accurate guess of where and at what context path **bootstrap.ign** will eventually be served 

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -1,6 +1,7 @@
 helper_vm_ip: 192.168.86.180
 bootstrap_ignition_url: "http://{{helper_vm_ip}}:8080/ignition/bootstrap.ign"  
 config:
+  provider: vsphere
   base_domain: example.com
   cluster_name: ocp4
   installer_ssh_key: "{{ lookup('file', '~/.ssh/ocp4.pub') }}"

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -1,6 +1,7 @@
 helper_vm_ip: 192.168.86.180
 bootstrap_ignition_url: "http://{{helper_vm_ip}}:8080/ignition/bootstrap.ign"  
 config:
+  provider: vsphere
   base_domain: example.com
   cluster_name: ocp4
   installer_ssh_key: "{{ lookup('file', '~/.ssh/ocp4.pub') }}"
@@ -35,7 +36,7 @@ static_ip:
   netmask: 255.255.255.0
   network_interface_name: ens192
 proxy:
-  enabled: true
+  enabled: false
   http_proxy: http://helper.ocp4.example.com:3129
   https_proxy: http://helper.ocp4.example.com:3129
   no_proxy: example.com
@@ -44,7 +45,7 @@ proxy:
         <certficate content>
     -----END CERTIFICATE-----  
 registry:
-  enabled: true
+  enabled: false
   product_repo: openshift-release-dev
   product_release_name: ocp-release
   product_release_version: 4.4.0-x86_64

--- a/roles/common/templates/install-config.yaml.j2
+++ b/roles/common/templates/install-config.yaml.j2
@@ -3,7 +3,11 @@ baseDomain: {{ config.base_domain }}
 compute:
 - hyperthreading: Enabled   
   name: worker
-  replicas: 0 
+{% if config.provider is defined and 'none' in config.provider %}
+  replicas: {{ worker_vms | length }}
+{% else %}
+  replicas: 0
+{% endif %}
 controlPlane:
   hyperthreading: Enabled   
   name: master
@@ -11,12 +15,16 @@ controlPlane:
 metadata:
   name: {{ config.cluster_name }}
 platform:
+{% if config.provider is defined and 'none' in config.provider %}
+  none: {}
+{% else %}
   vsphere:
     vcenter: {{ vcenter.ip }}
     username: {{ vcenter.service_account_username }}
     password: {{ vcenter.service_account_password }}
     datacenter: {{ vcenter.datacenter }}
     defaultDatastore: {{ vcenter.datastore }}
+{% endif %}
 pullSecret: '{{ config.pull_secret | to_json }}'
 sshKey: '{{ config.installer_ssh_key }}'
 {% if proxy is defined and proxy.enabled == true %}

--- a/roles/vmware/tasks/main.yml
+++ b/roles/vmware/tasks/main.yml
@@ -1,6 +1,7 @@
   - name: Check if the vCenter folder already exists 
     command: "govc folder.info {{ folder }}"
-    register: folder_exists 
+    register: folder_exists
+    ignore_errors: yes
 
   - name: Create the vCenter folder by the same name as the cluster, only if it doesn't exist
     command: "govc folder.create {{ folder }}"


### PR DESCRIPTION
This change adds the ability to disable the vsphere cloud provider at installation time. 

This is particularly useful for "mixed" clusters with both VM and Bare Metal Nodes.  Adding Bare Metal nodes to a vSphere install is not a supported configuration, since the MachineConfig's will contain a kubelet argument specifying `--cloud-provider=vsphere`.  This causes pod failures when the kubelet tries to mount a datastore PV on the node.  

A new attribute was added to `group_vars/all/yaml` under the `config:` section named `provider:`
If this is absent or defined as anything other than `none`, the vsphere cloudprovider will be enabled.  This maintains backwards compatibility.