### PR TITLE
Need to move ssh tasks in pre_install.yml to beginning to prevent error

### DIFF
--- a/roles/common/tasks/pre_install.yml
+++ b/roles/common/tasks/pre_install.yml
@@ -1,3 +1,14 @@
+    - name: Create ~/.ssh directory if it does not exist
+      file:
+        path: ~/.ssh
+        state: directory
+        mode: '0755'
+  
+    - name: Generate a SSH key-pair
+      openssh_keypair:
+        path: ~/.ssh/ocp4
+        force: false
+  
     - name: Set the datacenter variable 
       set_fact:
         datacenter: "{{ vcenter.datacenter }}"
@@ -45,17 +56,6 @@
       pip: 
         name: pyvmomi
       become: true
-  
-    - name: Create ~/.ssh directory if it does not exist
-      file:
-        path: ~/.ssh
-        state: directory
-        mode: '0755'
-  
-    - name: Generate a SSH key-pair
-      openssh_keypair:
-        path: ~/.ssh/ocp4
-        force: false
   
     - name: Clean up existing bin, install-dir and downloads folders
       file: 


### PR DESCRIPTION
Create the ssh key first in pre_install.yml so subsequent step doesn't fail due to the key not existing for the lookup plugin.