### PR TITLE
Remove master machine and worker machineset manifests

### DIFF
--- a/roles/common/tasks/install.yml
+++ b/roles/common/tasks/install.yml
@@ -6,9 +6,21 @@
         src: "cluster-scheduler-02-config.yml.patch"
         dest: "{{ playbook_dir }}/install-dir/manifests/cluster-scheduler-02-config.yml"
 
+    - name: Remove Master Machine manifests
+      file:
+        path: "{{ item }}"
+        state: absent
+      with_fileglob:
+        - "{{ playbook_dir }}/install-dir/openshift/99_openshift-cluster-api_master-machines-*.yaml"
+
+    - name: Remove Worker MachineSet manifest
+      file:
+        path: "{{ playbook_dir }}/install-dir/openshift/99_openshift-cluster-api_worker-machineset-0.yaml"
+        state: absent
+
     - name: Configure custom ntp servers for masters and workers
       when: ntp.custom
-      include_tasks: configure_ntp.yml 
+      include_tasks: configure_ntp.yml
 
     - name: Generate the ignition configs
       command: "openshift-install create ignition-configs --dir={{ playbook_dir }}/install-dir"


### PR DESCRIPTION
Per [OCP 4.5 documentation](https://docs.openshift.com/container-platform/4.5/installing/installing_vsphere/installing-vsphere.html#installation-user-infra-generate-k8s-manifest-ignition_installing-vsphere) for performing VMware UPI installation the Master Machine and Worker MachineSet manifests should be deleted prior to the creation of the Ignition files.

This PR addresses adds the needed code to remove these 4 files.