### PR TITLE
Add ability to customer Memory, CPU, and HDD sizes of nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ As it stands right now, the repo works for several installation use cases:
 ## Quickstart
 This is a concise summary of everything you need to do to use the repo. Rest of the document goes into details of every step.
 1. Setup [helper node](https://github.com/RedHatOfficial/ocp4-helpernode)
-2. Edit `group_vars/all.yml`, the following must be changed while the rest can remain the same
+2. Edit `group_vars/all.yml`, the following must be changed while the rest can remain the same:
    * pull secret
    * ip and mac addresses, host/domain names
    * enable/disable fips mode
@@ -24,8 +24,9 @@ This is a concise summary of everything you need to do to use the repo. Rest of 
      * datacenter name
      * username and passwords of admin/service accounts
    * enable/disable registry/proxy/ntp with their details, as required
-3. Customize `ansible.cfg` and use/copy/modify `staging` inventory file as required
-4. Run one of the several [install options](#run-installation-playbook)
+3. You can customize the CPU, Memory, and Hard Drive sizes for the bootstrap, masters, and workers in `group_vars/all.yml`. The recommended sizes are predefined.
+4. Customize `ansible.cfg` and use/copy/modify `staging` inventory file as required
+5. Run one of the several [install options](#run-installation-playbook)
 
 ## Infrastructure Prerequisites
 

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -24,15 +24,15 @@ download:
   dependencies_url: https://mirror.openshift.com/pub/openshift-v4/x86_64/dependencies/rhcos/latest/latest
   govc: https://github.com/vmware/govmomi/releases/download/v0.22.1/govc_linux_amd64.gz
 bootstrap_vms:
-  - { name: "bootstrap", macaddr: "00:50:56:a8:aa:a1", ipaddr: "192.168.86.181"}
+  - { name: "bootstrap", macaddr: "00:50:56:a8:aa:a1", ipaddr: "192.168.86.181", cpu_count: "4", mem_mb: "16384", disk_gb: "120" }
 master_vms:
-  - { name: "master0", macaddr: "00:50:56:a8:aa:a2", ipaddr: "192.168.86.182"}
-  - { name: "master1", macaddr: "00:50:56:a8:aa:a3", ipaddr: "192.168.86.183"}
-  - { name: "master2", macaddr: "00:50:56:a8:aa:a4", ipaddr: "192.168.86.184"}
+  - { name: "master0", macaddr: "00:50:56:a8:aa:a2", ipaddr: "192.168.86.182", cpu_count: "4", mem_mb: "16384", disk_gb: "120" }
+  - { name: "master1", macaddr: "00:50:56:a8:aa:a3", ipaddr: "192.168.86.183", cpu_count: "4", mem_mb: "16384", disk_gb: "120" }
+  - { name: "master2", macaddr: "00:50:56:a8:aa:a4", ipaddr: "192.168.86.184", cpu_count: "4", mem_mb: "16384", disk_gb: "120" }
 worker_vms:
-  - { name: "worker0", macaddr: "00:50:56:a8:aa:a5", ipaddr: "192.168.86.185"}
-  - { name: "worker1", macaddr: "00:50:56:a8:aa:a6", ipaddr: "192.168.86.186"}
-  - { name: "worker2", macaddr: "00:50:56:a8:aa:a7", ipaddr: "192.168.86.187"}
+  - { name: "worker0", macaddr: "00:50:56:a8:aa:a5", ipaddr: "192.168.86.185", cpu_count: "4", mem_mb: "16384", disk_gb: "120" }
+  - { name: "worker1", macaddr: "00:50:56:a8:aa:a6", ipaddr: "192.168.86.186", cpu_count: "4", mem_mb: "16384", disk_gb: "120" }
+  - { name: "worker2", macaddr: "00:50:56:a8:aa:a7", ipaddr: "192.168.86.187", cpu_count: "4", mem_mb: "16384", disk_gb: "120" }
 static_ip:
   gateway: 192.168.86.1
   netmask: 255.255.255.0

--- a/roles/dhcp_ova/tasks/main.yml
+++ b/roles/dhcp_ova/tasks/main.yml
@@ -61,12 +61,12 @@
       state: "{{ vcenter.vm_power_state }}"
       template: "{{ vcenter.template_name }}"
       disk:
-      - size_gb: 120
+      - size_gb: "{{ item.disk_gb }}"
         type: thin
         datastore: "{{ vcenter.datastore }}"
       hardware:
-        memory_mb: 16384
-        num_cpus: 4
+        memory_mb: "{{ item.mem_mb }}"
+        num_cpus: "{{ item.cpu_count }}"
         memory_reservation_lock: True
       networks:
       - name: "{{ vcenter.network }}"
@@ -89,12 +89,12 @@
       state: "{{ vcenter.vm_power_state }}"
       template: "{{ vcenter.template_name }}"
       disk:
-      - size_gb: 120
+      - size_gb: "{{ item.disk_gb }}"
         type: thin
         datastore: "{{ vcenter.datastore }}"
       hardware:
-        memory_mb: 16384
-        num_cpus: 4
+        memory_mb: "{{ item.mem_mb }}"
+        num_cpus: "{{ item.cpu_count }}"
         memory_reservation_lock: True
       networks:
       - name: "{{ vcenter.network }}"
@@ -117,12 +117,12 @@
       state: "{{ vcenter.vm_power_state }}"
       template: "{{ vcenter.template_name }}"
       disk:
-      - size_gb: 120
+      - size_gb: "{{ item.disk_gb }}"
         type: thin
         datastore: "{{ vcenter.datastore }}"
       hardware:
-        memory_mb: 16384
-        num_cpus: 4
+        memory_mb: "{{ item.mem_mb }}"
+        num_cpus: "{{ item.cpu_count }}"
         memory_reservation_lock: True
       networks:
       - name: "{{ vcenter.network }}"

--- a/roles/dhcp_pxe/tasks/main.yml
+++ b/roles/dhcp_pxe/tasks/main.yml
@@ -10,18 +10,19 @@
       name: "{{ item.name }}"
       state: "{{ vcenter.vm_power_state }}"
       disk:
-      - size_gb: 120
+      - size_gb: "{{ item.disk_gb }}"
         type: thin
         datastore: "{{ vcenter.datastore }}"
       hardware:
-        memory_mb: 16384
-        num_cpus: 4
+        memory_mb: "{{ item.mem_mb }}"
+        num_cpus: "{{ item.cpu_count }}"
         memory_reservation_lock: True
       networks:
       - name: "{{ vcenter.network }}"
         mac: "{{ item.macaddr }}"
       wait_for_ip_address: no
     loop: "{{ bootstrap_vms }}"
+
   - name: Create master VMs from the template
     vmware_guest:
       hostname: "{{ vcenter.ip }}"
@@ -34,12 +35,12 @@
       name: "{{ item.name }}"
       state: "{{ vcenter.vm_power_state }}"
       disk:
-      - size_gb: 120
+      - size_gb: "{{ item.disk_gb }}"
         type: thin
         datastore: "{{ vcenter.datastore }}"
       hardware:
-        memory_mb: 16384
-        num_cpus: 4
+        memory_mb: "{{ item.mem_mb }}"
+        num_cpus: "{{ item.cpu_count }}"
         memory_reservation_lock: True
       networks:
       - name: "{{ vcenter.network }}"
@@ -59,12 +60,12 @@
       name: "{{ item.name }}"
       state: "{{ vcenter.vm_power_state }}"
       disk:
-      - size_gb: 120
+      - size_gb: "{{ item.disk_gb }}"
         type: thin
         datastore: "{{ vcenter.datastore }}"
       hardware:
-        memory_mb: 16384
-        num_cpus: 4
+        memory_mb: "{{ item.mem_mb }}"
+        num_cpus: "{{ item.cpu_count }}"
         memory_reservation_lock: True
       networks:
       - name: "{{ vcenter.network }}"


### PR DESCRIPTION
Resolved issue #40 by allowing users to customize their nodes by setting CPU Count, Memory Size in MB, and Disk Size in GB.

The recommended settings are configured as the default. 