### PR TITLE
Add Playbooks for deploying Cluster with Static IPs from OVA

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,14 @@ ansible-playbook -i staging restricted_dhcp_ova.yml
 
 # Option 5: Static IPs + use of ISO images in a Restricted Network
 ansible-playbook -i staging restricted_static_ips.yml
+
+# Option 6: Static IPs + use of OVA template
+# Note: OpenShift 4.6 or higher required
+ansible-playbook -i staging static_ips_ova.yml
+
+# Option 7: Static IPs + use of OVA template in a Restricted Network
+# Note: OpenShift 4.6 or higher required
+ansible-playbook -i staging restricted_static_ips_ova.yml
 ```
 
 ### Miscellaneous

--- a/restricted_static_ips_ova.yml
+++ b/restricted_static_ips_ova.yml
@@ -58,3 +58,7 @@
     - name: Run steps specific to DHCP and the use of an OVA file
       import_role:
         name: static_ips_ova
+
+    - name: Run steps to finish cluster install
+      import_role:
+        name: finish_install

--- a/restricted_static_ips_ova.yml
+++ b/restricted_static_ips_ova.yml
@@ -1,0 +1,60 @@
+---
+- hosts: localhost
+  gather_facts: False
+  tasks:
+    - name: Set the cache of all the download links
+      import_role:
+        name: cache
+
+- hosts: localhost
+  gather_facts: True
+  environment:
+    PATH: "{{ playbook_dir }}/bin:{{ ansible_env.PATH }}"
+  tasks:
+    - name: Run all the common pre-install tasks
+      import_role:
+        name: common
+        tasks_from: pre_install
+
+- hosts: registries
+  gather_facts: False
+  tasks:
+    - name: Run the setup tasks for a restricted environment
+      import_role:
+        name: restricted
+        tasks_from: setup_registry
+
+- hosts: localhost
+  gather_facts: False
+  tasks:
+    - name: Run the tasks for a restricted environment
+      import_role:
+        name: restricted
+        tasks_from: utilize_registry
+
+- hosts: localhost
+  gather_facts: False
+  environment:
+    PATH: "{{ playbook_dir }}/bin:{{ ansible_env.PATH }}"
+  tasks:
+    - name: Run all the common tasks
+      import_role:
+        name: common
+        tasks_from: install
+
+- hosts: localhost
+  gather_facts: False
+  environment:
+    PATH: "{{ playbook_dir }}/bin:{{ ansible_env.PATH }}"
+    GOVC_USERNAME: "{{ vcenter.admin_username }}"
+    GOVC_PASSWORD: "{{ vcenter.admin_password }}"
+    GOVC_URL: "https://{{ vcenter.ip }}"
+    GOVC_DATACENTER: "{{ datacenter }}"
+    GOVC_INSECURE: 1
+  tasks:
+    - name: Run the vmware role to setup vCenter folder
+      import_role:
+        name: vmware
+    - name: Run steps specific to DHCP and the use of an OVA file
+      import_role:
+        name: static_ips_ova

--- a/roles/static_ips_ova/tasks/main.yml
+++ b/roles/static_ips_ova/tasks/main.yml
@@ -1,0 +1,142 @@
+  - name: Download the ova file
+    get_url:
+      url: "{{ download.ova }}"
+      dest: "{{ playbook_dir }}/downloads/{{ vcenter.template_name }}.ova"
+      validate_certs: no
+    when: skip_ova is not defined
+
+  - name: Deploy the OVF template into the folder
+    vmware_deploy_ovf:
+      hostname: "{{ vcenter.ip }}"
+      username: "{{ vcenter.admin_username }}"
+      password: "{{ vcenter.admin_password }}"
+      datacenter: "{{ vcenter.datacenter }}"
+      datastore: "{{ vcenter.datastore }}"
+      folder: "{{ vcenter.folder_absolute_path }}"
+      name: '{{ vcenter.template_name }}'
+      allow_duplicates: False
+      disk_provisioning: thin
+      networks: "{u'VM Network':u'{{ vcenter.network }}'}"
+      ova: "{{ playbook_dir }}/downloads/{{ vcenter.template_name }}.ova"
+      power_on: False
+      validate_certs: False
+    when: skip_ova is not defined
+
+  - name: Remove the Network Adapter
+    command: "govc device.remove -vm {{ vcenter.folder_absolute_path }}/{{ vcenter.template_name }} ethernet-0"
+    when: skip_ova is not defined
+
+  - name: Update VM options on the template
+    command: "govc vm.change -vm {{ vcenter.folder_absolute_path }}/{{ vcenter.template_name }} -latency high -e=disk.EnableUUID=TRUE -e=guestinfo.ignition.config.data.encoding=base64 -e=guestinfo.ignition.config.data=blah" # noqa 204
+    when: skip_ova is not defined
+
+  - name: "Bootstrap base64"
+    debug:
+      msg: "{{ BootstrapContent }}"
+      verbosity: 1
+
+  - name: "Master base64"
+    debug:
+      msg: "{{ masterContent }}"
+      verbosity: 1
+
+  - name: "Worker base64 "
+    debug:
+      msg: "{{ workerContent }}"
+      verbosity: 1
+
+  - name: Create bootstrap VM from the template
+    vmware_guest:
+      hostname: "{{ vcenter.ip }}"
+      username: "{{ vcenter.service_account_username }}"
+      password: "{{ vcenter.service_account_password }}"
+      datacenter: "{{ vcenter.datacenter }}"
+      validate_certs: no
+      folder: "{{ vcenter.folder_absolute_path }}"
+      name: "{{ item.name }}"
+      state: "{{ vcenter.vm_power_state }}"
+      template: "{{ vcenter.template_name }}"
+      disk:
+      - size_gb: 120
+        type: thin
+        datastore: "{{ vcenter.datastore }}"
+      hardware:
+        memory_mb: 16384
+        num_cpus: 4
+        memory_reservation_lock: True
+      networks:
+      - name: "{{ vcenter.network }}"
+        mac: "{{ item.macaddr }}"
+      wait_for_ip_address: no
+      customvalues:
+        - key: guestinfo.ignition.config.data
+          value: "{{ BootstrapContent }}"
+        - key: guestinfo.ignition.config.data.encoding
+          value: base64
+        - key: guestinfo.afterburn.initrd.network-kargs
+          value: "ip={{ item.ipaddr }}::{{ static_ip.gateway }}:{{ static_ip.netmask }}:{{ item.name }}:ens192:off:{{ static_ip.dns }}"
+    loop: "{{ bootstrap_vms }}"
+
+  - name: Create master VMs from ther template
+    vmware_guest:
+      hostname: "{{ vcenter.ip }}"
+      username: "{{ vcenter.service_account_username }}"
+      password: "{{ vcenter.service_account_password }}"
+      datacenter: "{{ vcenter.datacenter }}"
+      validate_certs: no
+      folder: "{{ vcenter.folder_absolute_path }}"
+      name: "{{ item.name }}"
+      state: "{{ vcenter.vm_power_state }}"
+      template: "{{ vcenter.template_name }}"
+      disk:
+      - size_gb: 120
+        type: thin
+        datastore: "{{ vcenter.datastore }}"
+      hardware:
+        memory_mb: 16384
+        num_cpus: 4
+        memory_reservation_lock: True
+      networks:
+      - name: "{{ vcenter.network }}"
+        mac: "{{ item.macaddr }}"
+      wait_for_ip_address: no
+      customvalues:
+       - key: guestinfo.ignition.config.data
+         value: "{{ masterContent }}"
+       - key: guestinfo.ignition.config.data.encoding
+         value: base64
+       - key: guestinfo.afterburn.initrd.network-kargs
+         value: "ip={{ item.ipaddr }}::{{ static_ip.gateway }}:{{ static_ip.netmask }}:{{ item.name }}:ens192:off:{{ static_ip.dns }}"
+    loop: "{{ master_vms }}"
+
+  - name: Create worker VMs from the template
+    vmware_guest:
+      hostname: "{{ vcenter.ip }}"
+      username: "{{ vcenter.service_account_username }}"
+      password: "{{ vcenter.service_account_password }}"
+      datacenter: "{{ vcenter.datacenter }}"
+      validate_certs: no
+      folder: "{{ vcenter.folder_absolute_path }}"
+      name: "{{ item.name }}"
+      state: "{{ vcenter.vm_power_state }}"
+      template: "{{ vcenter.template_name }}"
+      disk:
+      - size_gb: 120
+        type: thin
+        datastore: "{{ vcenter.datastore }}"
+      hardware:
+        memory_mb: 16384
+        num_cpus: 4
+        memory_reservation_lock: True
+      networks:
+      - name: "{{ vcenter.network }}"
+        mac: "{{ item.macaddr }}"
+      wait_for_ip_address: no
+      customvalues:
+       - key: guestinfo.ignition.config.data
+         value: "{{ workerContent }}"
+       - key: guestinfo.ignition.config.data.encoding
+         value: base64
+       - key: guestinfo.afterburn.initrd.network-kargs
+         value: "ip={{ item.ipaddr }}::{{ static_ip.gateway }}:{{ static_ip.netmask }}:{{ item.name }}:ens192:off:{{ static_ip.dns }}"
+    loop: "{{ worker_vms }}"

--- a/roles/static_ips_ova/vars/main.yml
+++ b/roles/static_ips_ova/vars/main.yml
@@ -1,0 +1,3 @@
+masterContent: "{{ lookup('file', '{{ playbook_dir }}/install-dir/master.ign') | b64encode }}"
+workerContent: "{{ lookup('file', '{{ playbook_dir }}/install-dir/worker.ign') | b64encode }}"
+BootstrapContent: "{{ lookup('file', '{{ playbook_dir }}/install-dir/bootstrap.ign') | b64encode }}"

--- a/static_ips_ova.yml
+++ b/static_ips_ova.yml
@@ -32,3 +32,7 @@
     - name: Run steps specific to DHCP and the use of an OVA file
       import_role:
         name: static_ips_ova
+
+    - name: Run steps to finish cluster install
+      import_role:
+        name: finish_install

--- a/static_ips_ova.yml
+++ b/static_ips_ova.yml
@@ -1,0 +1,34 @@
+---
+- hosts: all
+  gather_facts: False
+  tasks:
+    - name: Set the cache of all the download links
+      import_role:
+        name: cache
+
+- hosts: localhost
+  gather_facts: True
+  environment:
+    PATH: "{{ playbook_dir }}/bin:{{ ansible_env.PATH }}"
+  tasks:
+    - name: Run all the common tasks
+      import_role:
+        name: common
+
+- hosts: localhost
+  gather_facts: False
+  environment:
+    PATH: "{{ playbook_dir }}/bin:{{ ansible_env.PATH }}"
+    GOVC_USERNAME: "{{ vcenter.admin_username }}"
+    GOVC_PASSWORD: "{{ vcenter.admin_password }}"
+    GOVC_URL: "https://{{ vcenter.ip }}"
+    GOVC_DATACENTER: "{{ datacenter }}"
+    GOVC_INSECURE: 1
+  tasks:
+    - name: Run the vmware role to setup vCenter folder
+      import_role:
+        name: vmware
+
+    - name: Run steps specific to DHCP and the use of an OVA file
+      import_role:
+        name: static_ips_ova


### PR DESCRIPTION
With the release of OCP 4.6 they have added the ability to deploy VMware OCP Nodes with static IP addresses by setting the network-kargs in ExtraConfig.

[Static IP configuration for vSphere using OVA
](https://docs.openshift.com/container-platform/4.6/release_notes/ocp-4-6-release-notes.html#ocp-4-6-static-ip-config-with-ova)
