### PR TITLE
Add --kubeconfig to oc commands; add Delete bootstrap

### DIFF
--- a/roles/finish_install/tasks/main.yml
+++ b/roles/finish_install/tasks/main.yml
@@ -7,32 +7,36 @@
      timeout: 3600
    register: result_wait
 
- - name: Wait for bootstrap to comlplete
-   command: openshift-install --dir={{ playbook_dir }}/install-dir wait-for bootstrap-complete --log-level debug
+ - name: Wait for bootstrap to complete
+   command: openshift-install --dir="{{ playbook_dir }}"/install-dir wait-for bootstrap-complete --log-level debug # noqa 301
    register: result_bootstrap
 
+ - name: Delete Bootstrap VM
+   command: "govc vm.destroy {{ bootstrap_vm.name }}"  # noqa 301
+   when: result_bootstrap.rc == 0
+
  - name: Wait for node-bootstraper csrs to approve
-   shell: oc get csr -o json | jq -r '.items[] | select(.status == {}) | .metadata.name'
+   shell: oc get csr -o json --kubeconfig="{{ playbook_dir }}"/install-dir/auth/kubeconfig | jq -r '.items[] | select(.status == {}) | .metadata.name' # noqa 301 306
    register: result_csr
    until: result_csr['stdout_lines']|count == worker_vms|count
    retries: 60
    delay: 60
 
  - name: Approve the csrs
-   command: oc adm certificate approve "{{ item }}"
+   command: oc adm certificate approve "{{ item }}" --kubeconfig="{{ playbook_dir }}"/install-dir/auth/kubeconfig # noqa 301
    loop: "{{ result_csr['stdout_lines'] }}"
 
  - name: Wait for system:node csrs to approve
-   shell: oc get csr -o json | jq -r '.items[] | select(.status == {}) | .metadata.name'
+   shell: oc get csr -o json --kubeconfig="{{ playbook_dir }}"/install-dir/auth/kubeconfig | jq -r '.items[] | select(.status == {}) | .metadata.name'  # noqa 301 306
    register: result_system
    until: result_system['stdout_lines']|count == worker_vms|count
    retries: 60
    delay: 60
 
  - name: Approve the csrs
-   command: oc adm certificate approve "{{ item }}"
+   command: oc adm certificate approve "{{ item }}" --kubeconfig="{{ playbook_dir }}"/install-dir/auth/kubeconfig # noqa 301
    loop: "{{ result_system['stdout_lines'] }}"
 
  - name: Wait for install complete
-   command: openshift-install wait-for install-complete --dir={{ playbook_dir }}/install-dir --log-level debug
+   command: openshift-install wait-for install-complete --dir={{ playbook_dir }}/install-dir --log-level debug # noqa 301
    register: result_complete

--- a/roles/finish_install/tasks/main.yml
+++ b/roles/finish_install/tasks/main.yml
@@ -40,3 +40,7 @@
  - name: Wait for install complete
    command: openshift-install wait-for install-complete --dir={{ playbook_dir }}/install-dir --log-level debug # noqa 301
    register: result_complete
+
+ - name: Output results from openshift-install wait-for install-complete
+   debug:
+     msg: "{{ result_complete.stderr | regex_findall('level=info.*') | list }}"


### PR DESCRIPTION
This PR adds the --kubeconfig option to all of the `oc` commands in the role finish_install. Additionally, it adds the task of deleting the bootstrap VM to match the IPI installer.

Additionally, I added the output of `openshift-install` so users have the kubeadmin password along with the link to the console.

Example:

```
TASK [finish_install_test : Output results from openshift-install wait-for install-complete] ************************************************************************************************************************************************
ok: [localhost] => {
    "msg": [
        "level=info msg=\"Waiting up to 40m0s for the cluster at https://api.openshift.lab.int:6443 to initialize...\"",
        "level=info msg=\"Waiting up to 10m0s for the openshift-console route to be created...\"",
        "level=info msg=\"Install complete!\"",
        "level=info msg=\"To access the cluster as the system:admin user when using 'oc', run 'export KUBECONFIG=/tmp/install-dir/auth/kubeconfig'\"",
        "level=info msg=\"Access the OpenShift web-console here: https://console-openshift-console.apps.openshift.example.com\"",
        "level=info msg=\"Login to the console with user: \\\"kubeadmin\\\", and password: \\\"PUTRg-vb4Sx-XAUaW-kgRue\\\"\"",
        "level=info msg=\"Time elapsed: 23m15s\""
    ]
}
```