### PR TITLE
add maxdistance to chrony.conf

### DIFF
--- a/roles/common/templates/chrony.conf.j2
+++ b/roles/common/templates/chrony.conf.j2
@@ -38,3 +38,5 @@ logdir /var/log/chrony
 
 # Select which information is logged.
 #log measurements statistics tracking
+
+maxdistance 16


### PR DESCRIPTION
For compliance with Windows AD servers serving as a NTP server, as described in https://access.redhat.com/solutions/4652771