### PR TITLE
Parent folder feature

### DIFF
--- a/clusters/ocp-example.yaml
+++ b/clusters/ocp-example.yaml
@@ -19,6 +19,7 @@ vcenter:
   datastore: datastore1
   iso_dir: ocp_install_isos
   network: "VM Network"
+  parent_folder: "/parent/folder/"
   # username: [CHANGE ME]
   # password: [CHANGE ME]
   datacenter: 'dc1'

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -19,6 +19,7 @@ vcenter:
   datastore: datastore1
   iso_dir: ocp_install_isos
   network: "VM Network"
+  parent_folder: "/parent/folder/"
   username: vsphere_admin_user #[CHANGE ME]
   password: vsphere_admin_pass #[CHANGE ME]
   datacenter: 'dc1'

--- a/roles/common/tasks/install.yml
+++ b/roles/common/tasks/install.yml
@@ -31,23 +31,3 @@
 
 - name: Generate the ignition configs
   command: "openshift-install create ignition-configs --dir={{ playbook_dir }}/install-dir" # noqa 301
-
-- name: Get Cluster infraID
-  command: jq -r .infraID "{{ playbook_dir }}/install-dir/metadata.json"
-  register: infraID
-  when: vcenter.folder_absolute_path is defined and vcenter.folder_absolute_path | type_debug == "NoneType"
-
-- name: Set the vcenter.infraID fact
-  set_fact:
-    vcenter_folder: "{{ infraID.stdout }}"
-  when: vcenter.folder_absolute_path is defined and vcenter.folder_absolute_path | type_debug == "NoneType"
-
-- name: Set the vcenter.folder_absolute_path if not provided
-  set_fact:
-    vcenter: "{{ vcenter | combine({'folder_absolute_path': '/'+datacenter+'/vm/'+vcenter_folder}, recursive=True) }}"
-  when: vcenter.folder_absolute_path is defined and vcenter.folder_absolute_path | type_debug == "NoneType"
-
-- name: Display the absolute folder path of the vCenter folder
-  debug:
-    var: vcenter.folder_absolute_path
-    verbosity: 1

--- a/roles/setup/tasks/main.yml
+++ b/roles/setup/tasks/main.yml
@@ -14,9 +14,13 @@
 - include_vars: "{{ clusters_folder }}/{{ cluster }}.yaml"
 
 - set_fact:
+    parent_folder: "{{ vcenter.parent_folder | regex_replace('^/', '') | regex_replace('/$', '') }}/"
+  when: vcenter.parent_folder is defined and vcenter.parent_folder is string
+
+- set_fact:
     webserverUri:  "{{ helper_vm_protocol }}://{{ helper_vm }}{% if helper_vm_port != 80 %}:{{ helper_vm_port }}{% endif %}"
     bootstrap_ignition_url: "{{ helper_vm_protocol }}://{{ helper_vm }}{% if helper_vm_port != 80 %}:{{ helper_vm_port }}{% endif %}/{{ cluster }}/ignition/bootstrap.ign"
-    vcenter: "{{ vcenter | combine({'folder_absolute_path': '/'+ vcenter.datacenter + '/vm/' + cluster}, recursive=True) }}"
+    vcenter: "{{ vcenter | combine({'folder_absolute_path': '/'+ vcenter.datacenter + '/vm/' + parent_folder | default('') + cluster}, recursive=True) }}"
 
 - name: Update config.cluster_base_version var
   vars:
@@ -70,3 +74,8 @@
   loop: "{{ nodes }}"
   loop_control:
     label: "{{ item.name }}"
+
+- name: Display the absolute folder path of the vCenter folder
+  debug:
+    var: vcenter.folder_absolute_path
+    verbosity: 0

--- a/roles/setup/tasks/main.yml
+++ b/roles/setup/tasks/main.yml
@@ -13,9 +13,15 @@
 
 - include_vars: "{{ clusters_folder }}/{{ cluster }}.yaml"
 
-- set_fact:
-    parent_folder: "{{ vcenter.parent_folder | regex_replace('^/', '') | regex_replace('/$', '') }}/"
-  when: vcenter.parent_folder is defined and vcenter.parent_folder is string
+- block:
+    - name: Check if parent folder looks correct 
+      fail:
+        msg: "Bailing out: vcenter.parent_folder does not look like a correct path '{{ vcenter.parent_folder }}' (cannot be just /)"
+      when: vcenter.parent_folder is not match('^\/?[a-zA-Z0-9_ -]+(\/[a-zA-Z0-9_ -]+)*\/?$')
+
+    - set_fact:
+        parent_folder: "{{ vcenter.parent_folder | regex_replace('^/', '') | regex_replace('/$', '') }}/"
+  when: vcenter.parent_folder is defined and vcenter.parent_folder
 
 - set_fact:
     webserverUri:  "{{ helper_vm_protocol }}://{{ helper_vm }}{% if helper_vm_port != 80 %}:{{ helper_vm_port }}{% endif %}"

--- a/roles/vsphere_vm/tasks/main.yml
+++ b/roles/vsphere_vm/tasks/main.yml
@@ -1,3 +1,35 @@
+- name: Check if parent folders exist (and create if needed)
+  block:
+    - name: Split path into parts
+      set_fact:
+        path_parts: "{{ parent_folder.split('/') |reject('match', '^$') }}"
+
+    - name: Debug path_parts
+      debug:
+        var: path_parts
+
+    - name: Build list of pairs (folder+parent)
+      set_fact:
+        path_pairs: "{{ path_pairs | default([]) + [pair] }}"
+      loop: "{{ range(path_parts|length) }}"
+      vars:
+        path_prefix: "{{ path_parts[:item]|join('/') }}"
+        pair: "{{ [path_parts[item], '/' ~ path_prefix] }}"
+
+    - name: Create the vCenter folder by the same name as the cluster, only if it doesn't exist
+      community.vmware.vcenter_folder:
+        hostname: "{{ vcenter.ip }}"
+        username: "{{ vcenter.username }}"
+        password: "{{ vcenter.password }}"
+        datacenter_name: "{{ vcenter.datacenter }}"
+        validate_certs: no
+        folder_name: "{{ item[0] }}"
+        folder_type: vm
+        parent_folder: "{{ item[1] if item[1] not in ['', '/'] else omit }}"
+        state: present
+      loop: "{{ path_pairs }}"
+  when: vcenter.parent_folder is defined and vcenter.parent_folder is string
+
 - name: Create the vCenter folder by the same name as the cluster, only if it doesn't exist
   community.vmware.vcenter_folder:
     hostname: "{{ vcenter.ip }}"

--- a/roles/vsphere_vm/tasks/main.yml
+++ b/roles/vsphere_vm/tasks/main.yml
@@ -7,6 +7,7 @@
     validate_certs: no
     folder_name: "{{ cluster }}"
     folder_type: vm
+    parent_folder: "{{ parent_folder }}"
     state: present
 
 - name: Encode node ignition files

--- a/roles/vsphere_vm/tasks/main.yml
+++ b/roles/vsphere_vm/tasks/main.yml
@@ -7,7 +7,7 @@
     validate_certs: no
     folder_name: "{{ cluster }}"
     folder_type: vm
-    parent_folder: "{{ parent_folder }}"
+    parent_folder: "{{ parent_folder | default(omit) }}"
     state: present
 
 - name: Encode node ignition files


### PR DESCRIPTION
Added a parent_folder, to allow creating the cluster folder and VMs in a parent folder, avoid storing all clusters at the DC root, and allow to organize by project for example.