### PR TITLE
Incorrect values of Proxy in jinja template

### DIFF
--- a/roles/common/templates/install-config.yaml.j2
+++ b/roles/common/templates/install-config.yaml.j2
@@ -42,9 +42,9 @@ pullSecret: '{{ config.pull_secret | to_json }}'
 sshKey: '{{ installer_ssh_key }}'
 {% if proxy is defined and proxy.enabled == true %}
 proxy:
-  http_proxy: {{ proxy.http_proxy }}
-  https_proxy: {{ proxy.https_proxy }}
-  no_proxy: {{ proxy.no_proxy }}
+  httpProxy: {{ proxy.http_proxy }}
+  httpsProxy: {{ proxy.https_proxy }}
+  noProxy: {{ proxy.no_proxy }}
 {% endif %}
 {% if registry is defined and registry.disconnected is defined and registry.disconnected == true %}
 imageContentSources:


### PR DESCRIPTION
Proxy values of the install-config must httpProxy or httpsProxy or noProxy instead http_proxy https_proxy and no_proxy. it will throw out an error when genereting the manifests files