### PR TITLE
Remove character "-" from vsphere_vm roles

### DIFF
--- a/roles/vsphere_vm/tasks/main.yml
+++ b/roles/vsphere_vm/tasks/main.yml
@@ -71,6 +71,6 @@
   vars:
     ip_alloc: "{% if dhcp | default(false) %}dhcp{% else %}static{% endif %}"
     medium: "{% if iso | default(false) | bool %}iso{% else %}ova{% endif %}"
-    name: "{% if ip_alloc == 'dhcp' %}{{ ip_alloc }}-{% else %}{{ ip_alloc }}-{{ medium }}{% endif %}.yml"
+    name: "{% if ip_alloc == 'dhcp' %}{{ ip_alloc }}{% else %}{{ ip_alloc }}-{{ medium }}{% endif %}.yml"
   include_tasks:
     file: "{{ name }}"


### PR DESCRIPTION
at the end of main file, depends from which deployment method you choose dhcp or static, a second playbook must be called. 

Here this character should not be there, otherwise in scenario 5, at the end, it will throw the error "could not run dhcp-.yaml"

This character is already present in the line for calling static-* playbooks.