### PR TITLE
Fix additionalTrustBundle not being added to install-config.yaml

### DIFF
--- a/roles/common/templates/install-config.yaml.j2
+++ b/roles/common/templates/install-config.yaml.j2
@@ -46,12 +46,16 @@ proxy:
   httpsProxy: {{ proxy.https_proxy }}
   noProxy: {{ proxy.no_proxy }}
 {% endif %}
+{% if registry is defined and registry.cert_content is defined %}
+additionalTrustBundle: |
+{{ registry.cert_content | indent(width=2, first=true) }}
+{% endif %}
 {% if registry is defined and registry.disconnected is defined and registry.disconnected == true %}
 imageContentSources:
 - mirrors:
-  - {{ registry.host }}/{{ registry.repo }}
+  - {{ registry.host }}:{{ registry.port }}/{{ registry.repo }}
   source: quay.io/{{ registry.product_repo }}/{{ registry.product_release_name }}
 - mirrors:
-  - {{ registry.host }}/{{ registry.repo }}
+  - {{ registry.host }}:{{ registry.port }}/{{ registry.repo }}
   source: quay.io/{{ registry.product_repo }}/ocp-v4.0-art-dev
 {% endif %}


### PR DESCRIPTION
Now adds additionalTrustBundle to install-config.yaml if cert_content is defined.

Also makes use of registry.port.